### PR TITLE
feat: Implement 'Read More' functionality for topics, documents, and …

### DIFF
--- a/frontend/src/app/dashboard/documents/page.tsx
+++ b/frontend/src/app/dashboard/documents/page.tsx
@@ -25,6 +25,7 @@ export default function DocumentsPage() {
   const [prompt, setPrompt] = useState("");
   const [uploading, setUploading] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState<Record<string, boolean>>({});
 
   const load = async () => {
     try {
@@ -192,9 +193,23 @@ export default function DocumentsPage() {
                 </div>
 
                 {d.summary && (
-                  <p className="text-sm text-gray-700 mt-3 line-clamp-5 whitespace-pre-wrap">
-                    {d.summary}
-                  </p>
+                  <>
+                    <p
+                      className={`text-sm text-gray-700 mt-3 whitespace-pre-wrap ${
+                        !showMore[d._id] && "line-clamp-5"
+                      }`}
+                    >
+                      {d.summary}
+                    </p>
+                    <button
+                      onClick={() =>
+                        setShowMore((p) => ({ ...p, [d._id]: !p[d._id] }))
+                      }
+                      className="text-sm text-blue-600 hover:underline"
+                    >
+                      {showMore[d._id] ? "Show Less" : "Read More"}
+                    </button>
+                  </>
                 )}
 
                 {d.processingError && (

--- a/frontend/src/app/dashboard/topics/page.tsx
+++ b/frontend/src/app/dashboard/topics/page.tsx
@@ -34,6 +34,7 @@ export default function TopicsPage() {
   const [editId, setEditId] = useState<string | null>(null);
   const [edit, setEdit] = useState<Partial<Topic>>({});
   const [actionId, setActionId] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState<Record<string, boolean>>({});
 
   const load = async () => {
     try {
@@ -232,9 +233,21 @@ export default function TopicsPage() {
                             {t.description}
                           </p>
                         )}
-                        <div className="mt-2 text-sm text-gray-800 line-clamp-5 whitespace-pre-wrap">
+                        <div
+                          className={`mt-2 text-sm text-gray-800 whitespace-pre-wrap ${
+                            !showMore[t._id] && "line-clamp-5"
+                          }`}
+                        >
                           {t.content || t.generatedContent}
                         </div>
+                        <button
+                          onClick={() =>
+                            setShowMore((p) => ({ ...p, [t._id]: !p[t._id] }))
+                          }
+                          className="text-sm text-blue-600 hover:underline"
+                        >
+                          {showMore[t._id] ? "Show Less" : "Read More"}
+                        </button>
                       </div>
                     )}
                   </div>

--- a/frontend/src/app/dashboard/websites/page.tsx
+++ b/frontend/src/app/dashboard/websites/page.tsx
@@ -25,6 +25,7 @@ export default function WebsitesPage() {
   const [url, setUrl] = useState("");
   const [creating, setCreating] = useState(false);
   const [actionId, setActionId] = useState<string | null>(null);
+  const [showMore, setShowMore] = useState<Record<string, boolean>>({});
 
   const load = async () => {
     try {
@@ -163,9 +164,23 @@ export default function WebsitesPage() {
                 </div>
 
                 {s.summary && (
-                  <p className="text-sm text-gray-700 mt-3 line-clamp-5 whitespace-pre-wrap">
-                    {s.summary}
-                  </p>
+                  <>
+                    <p
+                      className={`text-sm text-gray-700 mt-3 whitespace-pre-wrap ${
+                        !showMore[s._id] && "line-clamp-5"
+                      }`}
+                    >
+                      {s.summary}
+                    </p>
+                    <button
+                      onClick={() =>
+                        setShowMore((p) => ({ ...p, [s._id]: !p[s._id] }))
+                      }
+                      className="text-sm text-blue-600 hover:underline"
+                    >
+                      {showMore[s._id] ? "Show Less" : "Read More"}
+                    </button>
+                  </>
                 )}
 
                 {s.processingError && (


### PR DESCRIPTION
…websites

This commit introduces a "Read More" feature to the dashboard pages for topics, documents, and websites. This functionality replaces the previous text truncation with an expandable view, allowing users to see the full content of each item.

- Added a state variable to each page to manage the expanded/collapsed state of individual items.
- Conditionally applied the `line-clamp-5` CSS class to truncate text based on the item's state.
- Implemented a "Read More" / "Show Less" button to toggle the visibility of the full text content.